### PR TITLE
Dan testing

### DIFF
--- a/apps/minio/minio-deployment.yaml
+++ b/apps/minio/minio-deployment.yaml
@@ -1,0 +1,102 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: minio-sc
+provisioner: kubernetes.io/portworx-volume
+parameters:
+  repl: "3"
+  io_profile: "db"
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  # This name uniquely identifies the PVC. This is used in deployment.
+  name: minio-pv-claim
+  annotations:
+    volume.beta.kubernetes.io/storage-class: minio-sc
+spec:
+  # Read more about access modes here: http://kubernetes.io/docs/user-guide/persistent-volumes/#access-modes
+  accessModes:
+    # The volume is mounted as read-write by a single node
+    - ReadWriteOnce
+  resources:
+    # This is the request for storage. Should be available in the cluster.
+    requests:
+      storage: 10Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  # This name uniquely identifies the service
+  name: minio-service
+spec:
+  type: NodePort
+  ports:
+    - port: 9000
+      targetPort: 9000
+      protocol: TCP
+  selector:
+    # Looks for labels `app:minio` in the namespace and applies the spec
+    app: minio
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  # This name uniquely identifies the Deployment
+  name: minio
+spec:
+  strategy:
+    # Specifies the strategy used to replace old Pods by new ones
+    # Refer: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        # This label is used as a selector in Service definition
+        app: minio
+    spec:
+      # Volumes used by this deployment
+      volumes:
+      - name: data
+        # This volume is based on PVC
+        persistentVolumeClaim:
+          # Name of the PVC created earlier
+          claimName: minio-pv-claim
+      containers:
+      - name: minio
+        # Volume mounts for this container
+        volumeMounts:
+        # Volume 'data' is mounted to path '/data'
+        - name: data 
+          mountPath: "/data"
+        # Pulls the lastest Minio image from Docker Hub
+        image: minio/minio:RELEASE.2019-09-05T23-24-38Z
+        args:
+        - server
+        - /data
+        env:
+        # MinIO access key and secret key
+        - name: MINIO_ACCESS_KEY
+          value: "minio"
+        - name: MINIO_SECRET_KEY
+          value: "minio123"
+        ports:
+        - containerPort: 9000
+        # Readiness probe detects situations when MinIO server instance
+        # is not ready to accept traffic. Kubernetes doesn't forward
+        # traffic to the pod while readiness checks fail.
+        readinessProbe:
+          httpGet:
+            path: /minio/health/ready
+            port: 9000
+          initialDelaySeconds: 120
+          periodSeconds: 20
+        # Liveness probe detects situations where MinIO server instance
+        # is not working properly and needs restart. Kubernetes automatically
+        # restarts the pods if liveness checks fail.
+        livenessProbe:
+          httpGet:
+            path: /minio/health/live
+            port: 9000
+          initialDelaySeconds: 120
+          periodSeconds: 20

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -28,6 +28,18 @@ private_key_path = "/Users/joe/.ssh/id_rsa"
 
 ### Number of clusters
 clusters = ["1", "n"]
+
+### Stork version
+stork_version = latest
+
+### Storkctl version
+storkctl_version = latest
+
+### Portworx version
+portworx_version = 2.1.2
+
+### Kubernetes version
+kube_version = 1.15.3
 ```
 Note that the existing keypair name is a stored SSH keypair on AWS. Make sure it exists in your chosen region.
 

--- a/kubernetes/main.tf
+++ b/kubernetes/main.tf
@@ -250,7 +250,12 @@ resource "null_resource" "storkctl" {
   provisioner "remote-exec" {
     inline = [
 <<EOF
-if ssh -oStrictHostKeyChecking=no worker-c2-1 bash -c 'kubectl' ; then
+until ssh -oStrictHostKeyChecking=no worker-c2-1 pxctl status | grep 'PX is operational'
+do
+    echo "Waiting for PX Cluster to come online...."
+    sleep 10
+done
+if ssh -oStrictHostKeyChecking=no worker-c2-1 kubectl > /dev/null ; then
   while : ; do
     token=$(ssh -oConnectTimeout=1 -oStrictHostKeyChecking=no worker-c2-1 pxctl cluster token show | cut -f 3 -d " ")
     echo $token | grep -Eq '.{128}'

--- a/kubernetes/main.tf
+++ b/kubernetes/main.tf
@@ -136,7 +136,7 @@ resource "aws_instance" "master" {
       "kubectl create -f https://raw.githubusercontent.com/kubernetes/dashboard/master/aio/deploy/recommended/kubernetes-dashboard.yaml",
       
       # Stork binary installation
-      "sudo curl -s http://openstorage-stork.s3-website-us-east-1.amazonaws.com/storkctl/2.0.0/linux/storkctl -o /usr/bin/storkctl && sudo chmod +x /usr/bin/storkctl",
+      "sudo curl -s http://openstorage-stork.s3-website-us-east-1.amazonaws.com/storkctl/${var.storkctl_version}/linux/storkctl -o /usr/bin/storkctl && sudo chmod +x /usr/bin/storkctl",
 
     ]
   }
@@ -198,7 +198,7 @@ resource "aws_instance" "worker" {
       "sudo apt-get install -y kubeadm",
       "sudo systemctl enable docker kubelet && sudo systemctl restart docker kubelet",
       "sudo kubeadm config images pull",
-      "sudo docker pull portworx/oci-monitor:2.0.1 ; sudo docker pull openstorage/stork:2.0.1 ; sudo docker pull portworx/px-enterprise:2.0.1",
+      "sudo docker pull portworx/oci-monitor:2.0.1 ; sudo docker pull openstorage/stork:${var.stork_version}; sudo docker pull portworx/px-enterprise:2.0.1",
       "sudo kubeadm join 10.0.1.${var.clusters[count.index % length(var.clusters)]}0:6443 --token ${var.join_token} --discovery-token-unsafe-skip-ca-verification --node-name ${self.tags.Name}"
     ]
   }

--- a/kubernetes/main.tf
+++ b/kubernetes/main.tf
@@ -114,7 +114,7 @@ resource "aws_instance" "master" {
       "wait",
       "until docker; do sudo apt-get update && sudo apt-get install -y docker-ce docker-ce-cli containerd.io; sleep 2; done",
 
-      "sudo apt-get install -y kubeadm",
+      "sudo apt-get install -y kubeadm=${var.kube_version} kubelet=${var.kube_version} kubectl=${var.kube_version}",
       "sudo systemctl enable docker kubelet && sudo systemctl restart docker kubelet",
       "sudo kubeadm config images pull",
       "wait",
@@ -132,7 +132,7 @@ resource "aws_instance" "master" {
       "kubectl apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/master/example/prometheus-operator-crd/servicemonitor.crd.yaml",
       "sleep 30",
       "kubectl create secret generic alertmanager-portworx --from-file=/tmp/portworx-pxc-alertmanager.yaml -n kube-system",
-      "kubectl apply -f 'https://install.portworx.com/2.0.2?mc=false&kbver=1.13.3&b=true&c=px-demo-${count.index + 1}&stork=true&lh=true&mon=true&st=k8s'",
+      "kubectl apply -f 'https://install.portworx.com/2.0.2?mc=false&kbver=${var.kube_version}&b=true&c=px-demo-${count.index + 1}&stork=true&lh=true&mon=true&st=k8s'",
       "kubectl create -f https://raw.githubusercontent.com/kubernetes/dashboard/master/aio/deploy/recommended/kubernetes-dashboard.yaml",
       
       # Stork binary installation
@@ -195,7 +195,7 @@ resource "aws_instance" "worker" {
       "until docker; do sudo apt-get update && sudo apt-get install -y docker-ce docker-ce-cli containerd.io; sleep 2; done",
 
       "wait",
-      "sudo apt-get install -y kubeadm",
+      "sudo apt-get install -y kubeadm=${var.kube_version} kubelet=${var.kube_version} kubectl=${var.kube_version}",
       "sudo systemctl enable docker kubelet && sudo systemctl restart docker kubelet",
       "sudo kubeadm config images pull",
       "sudo docker pull portworx/oci-monitor:2.0.1 ; sudo docker pull openstorage/stork:${var.stork_version}; sudo docker pull portworx/px-enterprise:2.0.1",

--- a/kubernetes/main.tf
+++ b/kubernetes/main.tf
@@ -114,7 +114,7 @@ resource "aws_instance" "master" {
       "wait",
       "until docker; do sudo apt-get update && sudo apt-get install -y docker-ce docker-ce-cli containerd.io; sleep 2; done",
 
-      "sudo apt-get install -y kubeadm=${var.kube_version} kubelet=${var.kube_version} kubectl=${var.kube_version}",
+      "sudo apt-get install -y kubeadm=${var.kube_version}-00 kubelet=${var.kube_version}-00 kubectl=${var.kube_version}-00",
       "sudo systemctl enable docker kubelet && sudo systemctl restart docker kubelet",
       "sudo kubeadm config images pull",
       "wait",
@@ -195,7 +195,7 @@ resource "aws_instance" "worker" {
       "until docker; do sudo apt-get update && sudo apt-get install -y docker-ce docker-ce-cli containerd.io; sleep 2; done",
 
       "wait",
-      "sudo apt-get install -y kubeadm=${var.kube_version} kubelet=${var.kube_version} kubectl=${var.kube_version}",
+      "sudo apt-get install -y kubeadm=${var.kube_version}-00 kubelet=${var.kube_version}-00 kubectl=${var.kube_version}-00",
       "sudo systemctl enable docker kubelet && sudo systemctl restart docker kubelet",
       "sudo kubeadm config images pull",
       "sudo docker pull portworx/oci-monitor:${var.portworx_version} ; sudo docker pull openstorage/stork:${var.stork_version}; sudo docker pull portworx/px-enterprise:${var.portworx_version}",

--- a/kubernetes/main.tf
+++ b/kubernetes/main.tf
@@ -132,7 +132,7 @@ resource "aws_instance" "master" {
       "kubectl apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/master/example/prometheus-operator-crd/servicemonitor.crd.yaml",
       "sleep 30",
       "kubectl create secret generic alertmanager-portworx --from-file=/tmp/portworx-pxc-alertmanager.yaml -n kube-system",
-      "kubectl apply -f 'https://install.portworx.com/2.0.2?mc=false&kbver=${var.kube_version}&b=true&c=px-demo-${count.index + 1}&stork=true&lh=true&mon=true&st=k8s'",
+      "kubectl apply -f 'https://install.portworx.com/${var.portworx_version}?mc=false&kbver=${var.kube_version}&b=true&c=px-demo-${count.index + 1}&stork=true&lh=true&mon=true&st=k8s'",
       "kubectl create -f https://raw.githubusercontent.com/kubernetes/dashboard/master/aio/deploy/recommended/kubernetes-dashboard.yaml",
       
       # Stork binary installation
@@ -198,7 +198,7 @@ resource "aws_instance" "worker" {
       "sudo apt-get install -y kubeadm=${var.kube_version} kubelet=${var.kube_version} kubectl=${var.kube_version}",
       "sudo systemctl enable docker kubelet && sudo systemctl restart docker kubelet",
       "sudo kubeadm config images pull",
-      "sudo docker pull portworx/oci-monitor:2.0.1 ; sudo docker pull openstorage/stork:${var.stork_version}; sudo docker pull portworx/px-enterprise:2.0.1",
+      "sudo docker pull portworx/oci-monitor:${var.portworx_version} ; sudo docker pull openstorage/stork:${var.stork_version}; sudo docker pull portworx/px-enterprise:${var.portworx_version}",
       "sudo kubeadm join 10.0.1.${var.clusters[count.index % length(var.clusters)]}0:6443 --token ${var.join_token} --discovery-token-unsafe-skip-ca-verification --node-name ${self.tags.Name}"
     ]
   }

--- a/kubernetes/main.tf
+++ b/kubernetes/main.tf
@@ -229,6 +229,7 @@ resource "null_resource" "appdeploy" {
       "kubectl apply -f /tmp/apps/wordpress-db.yaml",
       "kubectl apply -f /tmp/apps/wordpress-deployment.yaml"
       #"kubectl apply -f /tmp/apps/jenkins-deployment.yaml"
+      #"kubectl apply -f /tmp/apps/minio-deployment.yaml"
     ] 
   }
 }

--- a/kubernetes/variables.tf
+++ b/kubernetes/variables.tf
@@ -32,3 +32,8 @@ variable "storkctl_version" {
   description = "Version of storkctl to use"
   default = "latest"
 }
+
+variable "kube_version" {
+  description = "Version of storkctl to use"
+  default = "1.15.3"
+}

--- a/kubernetes/variables.tf
+++ b/kubernetes/variables.tf
@@ -10,17 +10,17 @@
 ### Region
 variable "aws_region" {
   description = "The region to deploy the kubernetes clusters"
-  default=""
+  default="eu-west-2"
 }
 
 variable "key_name" {
   description = "Key pair name to use for SSH"
-  default = ""
+  default = "dwelc"
 }
 
 variable "private_key_path" {
   description = "Path to private SSH key"
-  default = ""
+  default = "~/Documents/ssh-sessions/aws/keys/dwelc.pem"
 }
 
 variable "stork_version" {

--- a/kubernetes/variables.tf
+++ b/kubernetes/variables.tf
@@ -34,6 +34,11 @@ variable "storkctl_version" {
 }
 
 variable "kube_version" {
-  description = "Version of storkctl to use"
+  description = "Version of kubernetes to use"
   default = "1.15.3"
+}
+
+variable "portworx_version" {
+  description = "Version of kubernetes to use"
+  default = "2.1.2"
 }

--- a/kubernetes/variables.tf
+++ b/kubernetes/variables.tf
@@ -22,3 +22,13 @@ variable "private_key_path" {
   description = "Path to private SSH key"
   default = ""
 }
+
+variable "stork_version" {
+  description = "Version of Stork to use"
+  default = "latest"
+}
+
+variable "storkctl_version" {
+  description = "Version of storkctl to use"
+  default = "latest"
+}


### PR DESCRIPTION
This PR adds the following:-

1. Minio deployment spec. Commented out, not applied by default
2. Variables for kubernetes, portworx and storkctl versions
3. A fix for the clusterpair generation. It now waits for 'pxctl status' to return that the cluster is online before it generates and applies clusterpair spec.

Tested on terraform 0.12.4