### PR TITLE
OpenShift 3.11 deployment, using CRI-O as the Container Runtime

### DIFF
--- a/openshift3-crio/README.md
+++ b/openshift3-crio/README.md
@@ -1,0 +1,42 @@
+# OpenShift 3.X w/ CRI-O Deploy
+This is a Terraform script to deploy OpenShift 3.11 with the Container Runtime being CRI-O (instead of Docker).  Portworx is not installed automatically
+
+You need to have Terraform >= 0.12 installed and your AWS credentials set in `~/.aws/credentials`
+
+`brew install terraform`
+
+## Instructions
+1. Clone the repo
+
+2. Change into the root of the repo and create a file to store your specific variable. Call the file `terraform.tfvars`
+Add the following values and change the examples below to match your needs:
+```
+### Region
+aws_region = "eu-west-2"
+
+### Existing keypair name
+key_name = "jgardiner"
+
+### Private ssh key for keypair path
+private_key_path = "/Users/joe/.ssh/id_rsa"
+
+### where a wildcard entry should already exists (e.g. *.apps.whateverdomain.com) that you would then point to the master node
+app_sub_domain = "whateverdomain.com"
+```
+Note that the existing keypair name is a stored SSH keypair on AWS. Make sure it exists in your chosen region.
+
+3. Initialise the repo with the required modules
+`terraform init`
+
+4. Run the Terraform plan
+`terraform plan`
+
+5. Run the deployment
+`terraform apply --auto-approve`
+
+## Environment
+- you can ssh between machines using the hosts in the hosts file `/etc/hosts`.
+- check the Terraform output for dashboard access
+- remember to use oc instead of kubectl!
+- kube config is set on the masters, no sudo required
+- there's a repo of demo app manifests pulled onto the master

--- a/openshift3-crio/files/hosts
+++ b/openshift3-crio/files/hosts
@@ -1,0 +1,6 @@
+10.0.1.10   master
+10.0.1.11   worker-1
+10.0.1.12   worker-2
+10.0.1.13   worker-3
+10.0.1.14   worker-4
+10.0.1.15   worker-5

--- a/openshift3-crio/files/inventory.tpl
+++ b/openshift3-crio/files/inventory.tpl
@@ -1,0 +1,30 @@
+[OSEv3:children]
+masters
+etcd
+nodes
+[OSEv3:vars]
+ansible_ssh_user=centos
+ansible_sudo=true
+ansible_become=true
+deployment_type=origin
+os_sdn_network_plugin_name='redhat/openshift-ovs-multitenant'
+openshift_install_examples=true
+openshift_use_crio=True
+openshift_use_crio_only=True
+openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 'challenge': 'true', 'kind': 'HTPasswdPasswordIdentityProvider'}]
+openshift_master_htpasswd_users={'admin' : '$apr1$zTCG/myL$mj1ZMOSkYg7a9NLZK9Tk9.'}
+openshift_master_default_subdomain=apps.${app_sub_domain}
+openshift_master_cluster_public_hostname=${master_public_ip}
+openshift_master_cluster_hostname=${master_public_ip}
+openshift_disable_check=disk_availability,docker_storage,memory_availability
+openshift_hosted_router_selector='node-role.kubernetes.io/infra=true'
+openshift_enable_service_catalog=false
+[masters]
+master
+[etcd]
+master
+[nodes]
+master openshift_node_group_name="node-config-master-infra-crio" openshift_schedulable=true
+worker-1 openshift_node_group_name="node-config-compute-crio"
+worker-2 openshift_node_group_name="node-config-compute-crio"
+worker-3 openshift_node_group_name="node-config-compute-crio"

--- a/openshift3-crio/files/prepare.yaml
+++ b/openshift3-crio/files/prepare.yaml
@@ -1,0 +1,32 @@
+---
+- hosts: nodes
+  gather_facts: no
+  pre_tasks:
+    - name: install python2
+      yum:
+        name: python
+        state: installed
+  tasks:
+  - name: install the latest version of podman
+    yum:
+      name: podman
+      state: latest
+  - name: install the latest version of NetworkManager
+    yum:
+      name: NetworkManager
+      state: installed
+  - name: enable network-manager
+    service:
+      name: NetworkManager
+      enabled: yes
+      state: started
+  - name: Add repository
+    yum_repository:
+       name: okd
+       description: OKD 311 repo
+       baseurl: https://rpms.svc.ci.openshift.org/openshift-origin-v3.11/
+       gpgcheck: no
+  - name: install the latest version of CRI-O
+    yum:
+      name: cri-tools
+      state: latest

--- a/openshift3-crio/main.tf
+++ b/openshift3-crio/main.tf
@@ -1,0 +1,233 @@
+#############################################################
+##
+## This app file contains the bootstrap of OpenShift Installation
+## on AWS
+## 
+## @year 2019
+## @author Joe Gardiner <joe@grdnr.io>
+##
+#############################################################
+
+# Specify the provider and access details
+provider "aws" {
+  region  = var.aws_region
+  version = "~> 2.0"
+}
+
+# Load the latest Centos AMI
+data "aws_ami" "centos" {
+  owners      = ["679593333241"]
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["CentOS Linux 7 x86_64 HVM EBS *"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+}
+
+module "aws_networking" {
+  source = "../modules/network"
+}
+
+resource "aws_instance" "master" {
+  tags = {
+    Name = "master"
+  }
+
+  connection {
+    type        = "ssh"
+    user        = "centos"
+    private_key = file(var.private_key_path)
+    host        = self.public_ip
+  }
+
+  associate_public_ip_address = true
+  private_ip                  = "10.0.1.10"
+
+  instance_type = "t2.large"
+  ami           = data.aws_ami.centos.id
+
+  key_name = var.key_name
+
+  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
+  # force an interpolation expression to be interpreted as a list by wrapping it
+  # in an extra set of list brackets. That form was supported for compatibility in
+  # v0.11, but is no longer supported in Terraform v0.12.
+  #
+  # If the expression in the following list itself returns a list, remove the
+  # brackets to avoid interpretation as a list of lists. If the expression
+  # returns a single list item then leave it as-is and remove this TODO comment.
+  vpc_security_group_ids = [module.aws_networking.security_group]
+  subnet_id              = module.aws_networking.subnet
+
+  root_block_device {
+    volume_type = "gp2"
+    volume_size = "100"
+  }
+
+  provisioner "file" {
+    source      = "files"
+    destination = "/tmp"
+  }
+  provisioner "file" {
+    source      = var.private_key_path
+    destination = "/home/centos/.ssh/id_rsa"
+  }
+  provisioner "remote-exec" {
+    inline = [
+      "sudo hostnamectl set-hostname ${self.tags.Name}",
+      "sudo chmod 600 /home/centos/.ssh/id_rsa",
+      "sudo cat /tmp/files/hosts | sudo tee --append /etc/hosts",
+      "sudo yum -y install git epel-release",
+      "sudo yum -y install python-pip",
+      "sudo pip install ansible",
+      "cd ~ && git clone https://github.com/openshift/openshift-ansible",
+      "mv /tmp/prepare.yaml openshift-ansible/.",
+      "cd ~ && git clone https://github.com/grdnrio/sa-toolkit.git",
+    ]
+  }
+}
+
+resource "aws_instance" "worker" {
+  connection {
+    type        = "ssh"
+    user        = "centos"
+    private_key = file(var.private_key_path)
+    host        = self.public_ip
+  }
+  depends_on    = [aws_instance.master]
+  count         = "3"
+  instance_type = "m4.4xlarge"
+  tags = {
+    Name = "worker-${count.index + 1}"
+  }
+  private_ip = "10.0.1.1${count.index + 1}"
+  ami        = data.aws_ami.centos.id
+  key_name   = var.key_name
+  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
+  # force an interpolation expression to be interpreted as a list by wrapping it
+  # in an extra set of list brackets. That form was supported for compatibility in
+  # v0.11, but is no longer supported in Terraform v0.12.
+  #
+  # If the expression in the following list itself returns a list, remove the
+  # brackets to avoid interpretation as a list of lists. If the expression
+  # returns a single list item then leave it as-is and remove this TODO comment.
+  vpc_security_group_ids = [module.aws_networking.security_group]
+  subnet_id              = module.aws_networking.subnet
+  root_block_device {
+    volume_type = "gp2"
+    volume_size = "50"
+  }
+  ebs_block_device {
+    device_name = "/dev/sdd"
+    volume_type = "gp2"
+    volume_size = "80"
+  }
+  provisioner "file" {
+    source      = "files/hosts"
+    destination = "/tmp/hosts"
+  }
+  provisioner "file" {
+    source      = var.private_key_path
+    destination = "/home/centos/.ssh/id_rsa"
+  }
+  provisioner "remote-exec" {
+    inline = [
+      "sudo hostnamectl set-hostname ${self.tags.Name}",
+      "sudo chmod 600 /home/centos/.ssh/id_rsa",
+      "sudo cat /tmp/files/hosts | sudo tee --append /etc/hosts",
+    ]
+  }
+}
+
+data "template_file" "inventory" {
+  template   = file("files/inventory.tpl")
+  depends_on = [aws_instance.worker]
+  vars = {
+    master_public_ip = aws_instance.master.public_ip
+    app_sub_domain   = var.app_sub_domain
+  }
+}
+
+resource "null_resource" "inventory" {
+  triggers = {
+    template_rendered = data.template_file.inventory.rendered
+  }
+  connection {
+    user        = "centos"
+    private_key = file(var.private_key_path)
+    host        = aws_instance.master.public_ip
+  }
+  provisioner "file" {
+    content     = data.template_file.inventory.rendered
+    destination = "/tmp/inventory"
+  }
+}
+
+resource "null_resource" "ansible" {
+  triggers = {
+    version = timestamp()
+  }
+  depends_on = [null_resource.inventory]
+  connection {
+    user        = "centos"
+    private_key = file(var.private_key_path)
+    host        = aws_instance.master.public_ip
+  }
+  provisioner "remote-exec" {
+    inline = [
+      "cd openshift-ansible",
+      "git checkout release-3.11",
+      "ansible-playbook /tmp/files/prepare.yaml -i /tmp/inventory",
+      "ansible-playbook playbooks/prerequisites.yml -i /tmp/inventory",
+      "ansible-playbook playbooks/deploy_cluster.yml -i /tmp/inventory",
+    ]
+  }
+}
+
+resource "null_resource" "portworx" {
+  count    = 0
+  triggers = {
+    version = timestamp()
+  }
+  depends_on = [null_resource.ansible]
+  connection {
+    user        = "centos"
+    private_key = file(var.private_key_path)
+    host        = aws_instance.master.public_ip
+  }
+  provisioner "remote-exec" {
+    inline = [
+      "sleep 10",
+      "oc login -u system:admin -n default",
+      "sleep 5",
+      "oc adm policy add-scc-to-user privileged system:serviceaccount:kube-system:px-account",
+      "oc adm policy add-scc-to-user privileged system:serviceaccount:kube-system:portworx-pvc-controller-account",
+      "oc adm policy add-scc-to-user privileged system:serviceaccount:kube-system:px-lh-account",
+      "oc adm policy add-scc-to-user anyuid system:serviceaccount:kube-system:px-lh-account",
+      "oc adm policy add-scc-to-user anyuid system:serviceaccount:default:default",
+      "oc adm policy add-scc-to-user privileged system:serviceaccount:kube-system:px-csi-account",
+      "sleep 5",
+      "oc apply -f 'https://install.portworx.com/2.0?mc=false&kbver=1.11.0&b=true&s=%2Fdev%2Fxvdd&m=eth0&d=eth0&c=px-cluster-963cade8-8920-4000-a03d-2c8b0fb98727&osft=true&stork=true&lh=true&st=k8s'",
+    ]
+  }
+}
+
+output "master1_access" {
+  value = ["ssh centos@${aws_instance.master.public_ip}  then run oc login -u system:admin -n default"]
+}
+
+output "openshift_dashboard" {
+  value = ["https://${aws_instance.master.public_ip}:8443/console    -   admin:admin"]
+}
+

--- a/openshift3-crio/terraform.out
+++ b/openshift3-crio/terraform.out
@@ -1,0 +1,16 @@
+[0m[1mmodule.aws_networking.aws_vpc.default: Refreshing state... [id=vpc-0481e54bdd9635eaf][0m
+[0m[1mdata.aws_ami.centos: Refreshing state...[0m
+[0m[1mmodule.aws_networking.aws_internet_gateway.default: Refreshing state... [id=igw-008c73bd008a33d31][0m
+[0m[1mmodule.aws_networking.aws_subnet.default: Refreshing state... [id=subnet-02dd465f53f06420f][0m
+[0m[1mmodule.aws_networking.aws_security_group.default: Refreshing state... [id=sg-0637e44e04cffa210][0m
+[0m[1mmodule.aws_networking.aws_route.internet_access: Refreshing state... [id=r-rtb-05699ed78cc3ffb611080289494][0m
+[0m[1maws_instance.master: Refreshing state... [id=i-0c13f22a34dd48b5f][0m
+[0m[1maws_instance.worker[2]: Refreshing state... [id=i-00f7c3a5a3e5cc54b][0m
+[0m[1maws_instance.worker[0]: Refreshing state... [id=i-07f85bcf8bfd14c65][0m
+[0m[1maws_instance.worker[1]: Refreshing state... [id=i-0479f64db4bd146e4][0m
+[0m[1mnull_resource.inventory: Refreshing state... [id=7534978258871450948][0m
+[0m[1mnull_resource.ansible: Refreshing state... [id=694631606866485178][0m
+[0m[1mnull_resource.ansible: Destroying... [id=694631606866485178][0m[0m
+[0m[1mnull_resource.ansible: Destruction complete after 0s[0m[0m
+[0m[1mnull_resource.inventory: Destroying... [id=7534978258871450948][0m[0m
+[0m[1mnull_resource.inventory: Destruction complete after 0s[0m[0m

--- a/openshift3-crio/variables.tf
+++ b/openshift3-crio/variables.tf
@@ -1,0 +1,29 @@
+#############################################################
+##
+## This app file contains the variables of OPENSHIFT Installation
+## on AWS
+## 
+## @year 2019
+## @author Joe Gardiner <joe@grdnr.io>
+##
+#############################################################
+### Region
+variable "aws_region" {
+  description = "The region to deploy the kubernetes clusters"
+  default     = ""
+}
+
+variable "key_name" {
+  description = "Key pair name to use for SSH"
+  default     = ""
+}
+
+variable "private_key_path" {
+  description = "Path to private SSH key"
+  default     = ""
+}
+
+variable "app_sub_domain" {
+  description = "Domain under which apps subdomain will be accessible"
+  default     = ""
+}

--- a/openshift3-crio/versions.tf
+++ b/openshift3-crio/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
This PR sets up a fresh OpenShift 3.11 deployment with CRI-O as the container runetime.

cri-o on OpenShift clusters is needed because of SELINUX being set to enforcing

Additionally, i've upped the 3x worker node instance type to `m4.4xlarge` (which has 16vcpu and 64gb memory), as that is what is required for CloudPak 4 Data (what this demo environment is intended for).